### PR TITLE
Add CamJam sensor interfaces and documentation

### DIFF
--- a/docs/hardware/camjam-sensors.md
+++ b/docs/hardware/camjam-sensors.md
@@ -1,0 +1,58 @@
+# CamJam EduKit Sensor Requirements and Integration Guide
+
+## Overview
+The CamJam EduKit robotics bundle includes an ultrasonic ranging module, line-follow reflectance sensors, and optional wheel encoders. These peripherals extend the kit’s motor controller with obstacle detection, course alignment, and odometry telemetry. The goal of this document is to capture the functional requirements, wiring references, and calibration workflows that inform both the software interfaces and hardware integration.
+
+## Requirements Summary
+| Sensor | Purpose | Operating Range | Latency Budget | Telemetry Output |
+| --- | --- | --- | --- | --- |
+| HC-SR04 ultrasonic ranger | Detect obstacles and estimate forward distance | 0.02–4.0 m (nominal) | < 100 ms per sample | Calibrated distance in meters with confidence | 
+| QRE1113 line-follow reflectance modules (left/right) | Track surface contrast for line following | 0–100 % normalized reflectance | < 25 ms per sample | Normalized reflectance (0.0–1.0) with hysteresis flag |
+| Hall-effect wheel encoders | Optional odometry for both wheels | up to 100 Hz pulse rate | < 20 ms debounce | Wheel angular velocity (rad/s) and cumulative ticks |
+
+## Sensor-Specific Requirements
+
+### HC-SR04 Ultrasonic Ranger
+* **Trigger-to-echo timing**: Software must assert the trigger pin for 10 µs and measure echo pulse width using asynchronous capture.
+* **Conversion**: Use the speed of sound (343 m/s at 20°C) to translate echo duration into meters. Provide temperature compensation hook for future refinement.
+* **Noise rejection**: Apply a median filter across the last three samples and reject outliers beyond ±20 % of the rolling median.
+* **Telemetry**: Expose the filtered distance (float meters) plus a boolean flag indicating whether the value is considered valid.
+
+### Line-Follow Reflectance Modules
+* **Sampling**: Poll each reflectance sensor via ADC or GPIO timing every 10–20 ms.
+* **Normalization**: Convert raw readings to a normalized 0.0–1.0 reflectance value using calibration minima/maxima captured during setup.
+* **Debounce/Hysteresis**: Apply a simple exponential moving average (EMA) with α = 0.5 and track transitions crossing configurable thresholds to avoid chatter.
+* **Telemetry**: Provide per-sensor normalized reflectance and a combined `on_line` boolean if either sensor exceeds the active threshold.
+
+### Hall-Effect Wheel Encoders (Optional)
+* **Pulse handling**: Debounce pulses arriving up to 100 Hz using a 5 ms minimum inter-pulse interval.
+* **Velocity estimation**: Calculate wheel angular velocity by differentiating tick counts over the configured sample window.
+* **Calibration**: Support runtime configuration of ticks-per-revolution and wheel radius to convert ticks to linear distance.
+* **Telemetry**: Report cumulative tick count, angular velocity (rad/s), and optional linear velocity (m/s).
+
+## Wiring and Pin Mapping
+| Sensor | Pi GPIO Pins | Notes |
+| --- | --- | --- |
+| HC-SR04 | Trigger → BCM 23, Echo → BCM 24, VCC → 5V, GND → GND | Use level shifting or voltage divider on Echo if required |
+| Left Reflectance | VCC → 3.3V, GND → GND, Signal → BCM 17 | Adjust pin mapping to match controller hat |
+| Right Reflectance | VCC → 3.3V, GND → GND, Signal → BCM 27 | |
+| Left Encoder | VCC → 3.3V, GND → GND, Signal → BCM 5 | Optional pull-up resistor |
+| Right Encoder | VCC → 3.3V, GND → GND, Signal → BCM 6 | |
+
+> **Note**: Actual pin assignments may differ depending on the motor driver board revision. Update the table to match deployed hardware before running calibration.
+
+## Integration Workflow
+1. **Hardware Verification**: Confirm correct wiring, secure connections, and ensure sensors receive the expected supply voltage.
+2. **Software Configuration**: Install required GPIO libraries (e.g., `RPi.GPIO` or `gpiozero`) and configure the application to load the CamJam sensor modules.
+3. **Calibration**:
+   - **Ultrasonic**: Measure known distances (0.3 m, 0.6 m, 1.0 m) and adjust offset scaling using the provided calibration hook.
+   - **Reflectance**: Capture calibration minima/maxima by sweeping the robot over line and background surfaces; store values in configuration or non-volatile storage.
+   - **Encoders**: Rotate wheels through one revolution to record ticks-per-revolution and verify consistent direction readings.
+4. **Validation**: Run the automated test suite to confirm data normalization, debouncing, and telemetry outputs meet the specified thresholds.
+5. **Deployment**: Integrate the asynchronous sensor API into the motion controller to feed navigation and safety routines.
+
+## Maintenance Considerations
+* Periodically clean the reflectance sensors to prevent dust build-up altering calibration.
+* Re-run ultrasonic calibration when ambient temperature changes significantly.
+* Check encoder magnets and mounting hardware for slippage that could impact tick counts.
+

--- a/src/hardware/camjam/sensors/__init__.py
+++ b/src/hardware/camjam/sensors/__init__.py
@@ -1,0 +1,14 @@
+"""Sensor interfaces for the CamJam EduKit."""
+
+from .ultrasonic import UltrasonicRanger, UltrasonicReading
+from .line_follow import LineFollower, LineTelemetry
+from .encoders import WheelEncoders, EncoderTelemetry
+
+__all__ = [
+    "UltrasonicRanger",
+    "UltrasonicReading",
+    "LineFollower",
+    "LineTelemetry",
+    "WheelEncoders",
+    "EncoderTelemetry",
+]

--- a/src/hardware/camjam/sensors/encoders.py
+++ b/src/hardware/camjam/sensors/encoders.py
@@ -1,0 +1,124 @@
+"""Hall-effect wheel encoder aggregation and filtering."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Optional, Tuple
+
+
+SampleReader = Callable[[], Awaitable[Tuple[int, int, float]]]
+
+
+@dataclass
+class EncoderTelemetry:
+    """Normalized telemetry output for the pair of wheel encoders."""
+
+    cumulative_ticks_left: int
+    cumulative_ticks_right: int
+    angular_velocity_left: float
+    angular_velocity_right: float
+    linear_velocity_left: float
+    linear_velocity_right: float
+    valid: bool
+
+
+class WheelEncoders:
+    """Compute wheel velocities from raw hall-effect encoder ticks."""
+
+    def __init__(
+        self,
+        *,
+        sample_reader: SampleReader,
+        ticks_per_revolution: int = 20,
+        wheel_radius: float = 0.03,
+        min_interval: float = 0.005,
+    ) -> None:
+        if ticks_per_revolution <= 0:
+            raise ValueError("ticks_per_revolution must be positive")
+        if wheel_radius <= 0:
+            raise ValueError("wheel_radius must be positive")
+        if min_interval <= 0:
+            raise ValueError("min_interval must be positive")
+
+        self._sample_reader = sample_reader
+        self._ticks_per_revolution = ticks_per_revolution
+        self._wheel_radius = wheel_radius
+        self._min_interval = min_interval
+
+        self._last_valid_sample: Optional[Tuple[int, int, float]] = None
+
+    def calibrate(
+        self,
+        *,
+        ticks_per_revolution: Optional[int] = None,
+        wheel_radius: Optional[float] = None,
+    ) -> None:
+        """Update calibration constants for the encoder conversion."""
+
+        if ticks_per_revolution is not None:
+            if ticks_per_revolution <= 0:
+                raise ValueError("ticks_per_revolution must be positive")
+            self._ticks_per_revolution = ticks_per_revolution
+        if wheel_radius is not None:
+            if wheel_radius <= 0:
+                raise ValueError("wheel_radius must be positive")
+            self._wheel_radius = wheel_radius
+
+    async def read(self) -> EncoderTelemetry:
+        """Return filtered telemetry for the wheel encoders."""
+
+        sample = await self._sample_reader()
+        ticks_left, ticks_right, timestamp = sample
+
+        if self._last_valid_sample is None:
+            self._last_valid_sample = sample
+            return EncoderTelemetry(
+                cumulative_ticks_left=ticks_left,
+                cumulative_ticks_right=ticks_right,
+                angular_velocity_left=0.0,
+                angular_velocity_right=0.0,
+                linear_velocity_left=0.0,
+                linear_velocity_right=0.0,
+                valid=False,
+            )
+
+        last_left, last_right, last_time = self._last_valid_sample
+        delta_t = timestamp - last_time
+
+        if delta_t <= 0 or delta_t < self._min_interval:
+            return EncoderTelemetry(
+                cumulative_ticks_left=last_left,
+                cumulative_ticks_right=last_right,
+                angular_velocity_left=0.0,
+                angular_velocity_right=0.0,
+                linear_velocity_left=0.0,
+                linear_velocity_right=0.0,
+                valid=False,
+            )
+
+        delta_left = ticks_left - last_left
+        delta_right = ticks_right - last_right
+
+        angular_left = self._ticks_to_angular_velocity(delta_left, delta_t)
+        angular_right = self._ticks_to_angular_velocity(delta_right, delta_t)
+
+        linear_left = angular_left * self._wheel_radius
+        linear_right = angular_right * self._wheel_radius
+
+        self._last_valid_sample = sample
+
+        return EncoderTelemetry(
+            cumulative_ticks_left=ticks_left,
+            cumulative_ticks_right=ticks_right,
+            angular_velocity_left=angular_left,
+            angular_velocity_right=angular_right,
+            linear_velocity_left=linear_left,
+            linear_velocity_right=linear_right,
+            valid=True,
+        )
+
+    def _ticks_to_angular_velocity(self, delta_ticks: int, delta_t: float) -> float:
+        revolutions = delta_ticks / self._ticks_per_revolution
+        return revolutions * 2.0 * math.pi / delta_t
+

--- a/src/hardware/camjam/sensors/line_follow.py
+++ b/src/hardware/camjam/sensors/line_follow.py
@@ -1,0 +1,103 @@
+"""Line-follow sensor abstraction with normalization and hysteresis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Dict, Optional, Tuple
+
+
+AnalogReader = Callable[[], Awaitable[float]]
+
+
+@dataclass
+class LineTelemetry:
+    """Normalized readings for the pair of reflectance sensors."""
+
+    left: float
+    right: float
+    on_line: bool
+
+
+class LineFollower:
+    """Normalize raw reflectance values and apply hysteresis filtering."""
+
+    def __init__(
+        self,
+        *,
+        left_reader: AnalogReader,
+        right_reader: AnalogReader,
+        calibration: Optional[Dict[str, Tuple[float, float]]] = None,
+        ema_alpha: float = 0.5,
+        active_threshold: float = 0.6,
+        inactive_threshold: float = 0.4,
+    ) -> None:
+        if not 0.0 < ema_alpha <= 1.0:
+            raise ValueError("ema_alpha must be between 0 and 1")
+        if inactive_threshold > active_threshold:
+            raise ValueError("inactive_threshold must be <= active_threshold")
+
+        self._left_reader = left_reader
+        self._right_reader = right_reader
+        self._ema_alpha = ema_alpha
+        self._active_threshold = active_threshold
+        self._inactive_threshold = inactive_threshold
+
+        calibration = calibration or {}
+        self._calibration_left = calibration.get("left", (0.0, 1.0))
+        self._calibration_right = calibration.get("right", (0.0, 1.0))
+
+        self._ema_left: Optional[float] = None
+        self._ema_right: Optional[float] = None
+        self._on_line = False
+
+    def set_calibration(
+        self,
+        *,
+        left: Optional[Tuple[float, float]] = None,
+        right: Optional[Tuple[float, float]] = None,
+    ) -> None:
+        """Update the min/max calibration bounds."""
+
+        if left is not None:
+            self._calibration_left = left
+        if right is not None:
+            self._calibration_right = right
+
+    async def read(self) -> LineTelemetry:
+        """Return the current normalized telemetry from both sensors."""
+
+        raw_left = await self._left_reader()
+        raw_right = await self._right_reader()
+
+        normalized_left = self._normalize(raw_left, self._calibration_left)
+        normalized_right = self._normalize(raw_right, self._calibration_right)
+
+        self._ema_left = self._apply_ema(self._ema_left, normalized_left)
+        self._ema_right = self._apply_ema(self._ema_right, normalized_right)
+
+        self._update_hysteresis()
+
+        return LineTelemetry(left=self._ema_left, right=self._ema_right, on_line=self._on_line)
+
+    def _apply_ema(self, previous: Optional[float], current: float) -> float:
+        if previous is None:
+            return current
+        return self._ema_alpha * current + (1.0 - self._ema_alpha) * previous
+
+    def _normalize(self, value: float, bounds: Tuple[float, float]) -> float:
+        low, high = bounds
+        if high <= low:
+            return 0.0
+        normalized = (value - low) / (high - low)
+        return max(0.0, min(1.0, normalized))
+
+    def _update_hysteresis(self) -> None:
+        assert self._ema_left is not None and self._ema_right is not None
+
+        if not self._on_line:
+            if self._ema_left >= self._active_threshold or self._ema_right >= self._active_threshold:
+                self._on_line = True
+        else:
+            if self._ema_left < self._inactive_threshold and self._ema_right < self._inactive_threshold:
+                self._on_line = False
+

--- a/src/hardware/camjam/sensors/ultrasonic.py
+++ b/src/hardware/camjam/sensors/ultrasonic.py
@@ -1,0 +1,85 @@
+"""Asynchronous HC-SR04 ultrasonic sensor interface."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from statistics import median
+from typing import Awaitable, Callable, Deque, List, Optional
+
+
+EchoTimeReader = Callable[[], Awaitable[float]]
+
+
+@dataclass
+class UltrasonicReading:
+    """Telemetry for a single ultrasonic sensor measurement."""
+
+    distance_m: float
+    valid: bool
+
+
+class UltrasonicRanger:
+    """High-level HC-SR04 distance reader with filtering and calibration hooks."""
+
+    def __init__(
+        self,
+        *,
+        echo_time_reader: EchoTimeReader,
+        speed_of_sound: float = 343.0,
+        median_window: int = 3,
+        max_deviation: float = 0.2,
+        history_size: int = 5,
+    ) -> None:
+        if median_window < 1:
+            raise ValueError("median_window must be >= 1")
+
+        self._echo_time_reader = echo_time_reader
+        self._speed_of_sound = speed_of_sound
+        self._offset = 0.0
+        self._median_window = median_window
+        self._max_deviation = max_deviation
+        self._raw_samples: Deque[float] = deque(maxlen=median_window)
+        self._history: Deque[UltrasonicReading] = deque(maxlen=history_size)
+
+    def calibrate(self, *, speed_of_sound: Optional[float] = None, offset: Optional[float] = None) -> None:
+        """Adjust the conversion coefficients used for distance estimation."""
+
+        if speed_of_sound is not None:
+            self._speed_of_sound = speed_of_sound
+        if offset is not None:
+            self._offset = offset
+
+    @property
+    def history(self) -> List[UltrasonicReading]:
+        """Return the list of recent valid readings."""
+
+        return list(self._history)
+
+    async def read(self) -> UltrasonicReading:
+        """Trigger a measurement and return the filtered distance."""
+
+        echo_duration = await self._echo_time_reader()
+        raw_distance = self._offset + (echo_duration * self._speed_of_sound) / 2.0
+
+        self._raw_samples.append(raw_distance)
+        is_valid = self._is_within_deviation(raw_distance)
+
+        reading = UltrasonicReading(distance_m=raw_distance, valid=is_valid)
+        if is_valid:
+            self._history.append(reading)
+        return reading
+
+    def _is_within_deviation(self, raw_distance: float) -> bool:
+        """Check whether the new reading should be considered valid."""
+
+        if len(self._raw_samples) < self._median_window:
+            return True
+
+        window_median = median(self._raw_samples)
+        if window_median == 0:
+            return True
+
+        deviation = abs(raw_distance - window_median) / window_median
+        return deviation <= self._max_deviation
+

--- a/tests/hardware/sensors/test_camjam.py
+++ b/tests/hardware/sensors/test_camjam.py
@@ -1,0 +1,119 @@
+import asyncio
+from dataclasses import asdict
+
+import pytest
+
+from src.hardware.camjam.sensors.ultrasonic import UltrasonicRanger, UltrasonicReading
+from src.hardware.camjam.sensors.line_follow import LineFollower, LineTelemetry
+from src.hardware.camjam.sensors.encoders import WheelEncoders, EncoderTelemetry
+
+
+class AsyncIteratorStub:
+    def __init__(self, values):
+        self._iter = iter(values)
+
+    async def __call__(self):
+        return next(self._iter)
+
+
+def test_ultrasonic_distance_conversion_and_filtering():
+    echo_stub = AsyncIteratorStub([0.002, 0.0021, 0.009, 0.00205])
+    ranger = UltrasonicRanger(echo_time_reader=echo_stub)
+
+    async def run_test():
+        reading_1 = await ranger.read()
+        reading_2 = await ranger.read()
+        reading_3 = await ranger.read()
+        reading_4 = await ranger.read()
+
+        assert pytest.approx(reading_1.distance_m, rel=1e-3) == 0.343
+        assert reading_1.valid
+
+        assert pytest.approx(reading_2.distance_m, rel=1e-3) == 0.36015
+        assert reading_2.valid
+
+        assert not reading_3.valid, "Outlier should be flagged invalid"
+
+        assert pytest.approx(reading_4.distance_m, rel=1e-3) == 0.3513
+        assert reading_4.valid
+
+        history = ranger.history
+        assert all(r.valid for r in history)
+        assert reading_4 in history
+
+    asyncio.run(run_test())
+
+
+def test_line_follow_normalization_and_hysteresis():
+    left_stub = AsyncIteratorStub([100, 500, 800, 200])
+    right_stub = AsyncIteratorStub([900, 600, 200, 450])
+
+    follower = LineFollower(
+        left_reader=left_stub,
+        right_reader=right_stub,
+        calibration=dict(left=(100, 900), right=(200, 1000)),
+        active_threshold=0.6,
+        inactive_threshold=0.4,
+        ema_alpha=0.5,
+    )
+
+    async def run_test():
+        reading_1 = await follower.read()
+        reading_2 = await follower.read()
+        reading_3 = await follower.read()
+        reading_4 = await follower.read()
+
+        assert reading_1.on_line, "Initial reading should trip due to right sensor"
+        assert 0.0 <= reading_1.left <= 1.0
+        assert 0.0 <= reading_1.right <= 1.0
+
+        assert reading_2.on_line
+        assert reading_3.on_line
+        assert not reading_4.on_line, "Hysteresis should release once both fall below inactive threshold"
+
+        left_values = [reading_1.left, reading_2.left, reading_3.left, reading_4.left]
+        assert left_values[1] > left_values[0], "EMA should respond to increasing reflectance"
+        assert left_values[3] < left_values[2], "EMA should decay when readings drop"
+
+        telemetry_dict = asdict(reading_4)
+        assert set(telemetry_dict) == {"left", "right", "on_line"}
+
+    asyncio.run(run_test())
+
+
+def test_encoder_velocity_and_debounce():
+    sample_stub = AsyncIteratorStub([
+        (0, 0, 0.0),
+        (10, 10, 0.1),
+        (11, 11, 0.101),
+        (21, 21, 0.2),
+    ])
+
+    encoders = WheelEncoders(sample_reader=sample_stub, ticks_per_revolution=20, wheel_radius=0.03)
+    async def run_test():
+        reading_1 = await encoders.read()
+        reading_2 = await encoders.read()
+        reading_3 = await encoders.read()
+        reading_4 = await encoders.read()
+
+        assert reading_1.valid is False
+        assert reading_2.valid is True
+        assert pytest.approx(reading_2.angular_velocity_left, rel=1e-3) == pytest.approx(
+            reading_2.angular_velocity_right, rel=1e-3
+        )
+
+        assert reading_3.valid is False, "Debounce should reject near-simultaneous pulse spikes"
+        assert reading_3.cumulative_ticks_left == reading_2.cumulative_ticks_left
+
+        assert reading_4.valid is True
+        assert reading_4.cumulative_ticks_left == 21
+        assert reading_4.cumulative_ticks_right == 21
+        assert reading_4.angular_velocity_left > 0
+        assert reading_4.linear_velocity_left > 0
+
+        telemetry_dict = asdict(reading_4)
+        assert "linear_velocity_left" in telemetry_dict
+        assert "linear_velocity_right" in telemetry_dict
+
+    asyncio.run(run_test())
+


### PR DESCRIPTION
## Summary
- document CamJam EduKit sensor requirements, wiring, and calibration workflows
- add asynchronous sensor interfaces for the ultrasonic ranger, line followers, and wheel encoders
- create unit tests with stubs that validate conversion, filtering, and telemetry outputs

## Testing
- pytest tests/hardware/sensors/test_camjam.py

------
https://chatgpt.com/codex/tasks/task_e_68d976203018832f836f04e7dcab7532