### PR TITLE
Add CamJam control service spec, implementation, and tests

### DIFF
--- a/docs/api/control-service.yaml
+++ b/docs/api/control-service.yaml
@@ -1,0 +1,400 @@
+openapi: 3.1.0
+info:
+  title: Robby Control Service API
+  version: 0.1.0
+  description: |
+    REST API for commanding the CamJam differential-drive buggy, pan/tilt servos,
+    accessing ultrasonic and line-follow sensor telemetry, managing configuration,
+    and issuing emergency stop commands. All endpoints require a valid API key
+    issued to trusted local-network clients.
+  contact:
+    name: Robotics Platform Team
+servers:
+  - url: http://localhost:8080
+    description: Local development server
+  - url: http://robby-control.local
+    description: Production deployment on the robotics controller
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-Api-Key
+  schemas:
+    DifferentialDriveCommand:
+      type: object
+      required:
+        - left_speed
+        - right_speed
+      properties:
+        left_speed:
+          type: number
+          format: float
+          minimum: -1.0
+          maximum: 1.0
+          description: Normalized left motor speed command.
+        right_speed:
+          type: number
+          format: float
+          minimum: -1.0
+          maximum: 1.0
+          description: Normalized right motor speed command.
+        duration_s:
+          type: number
+          format: float
+          minimum: 0.0
+          exclusiveMinimum: true
+          description: Optional duration the command should be maintained before coasting.
+    DriveQueueResponse:
+      type: object
+      required:
+        - status
+        - queue_depth
+      properties:
+        status:
+          type: string
+          enum: [queued]
+        queue_depth:
+          type: integer
+          minimum: 0
+          description: Number of drive commands waiting to execute (including the new command).
+    PanTiltCommand:
+      type: object
+      required:
+        - pan_deg
+        - tilt_deg
+      properties:
+        pan_deg:
+          type: number
+          format: float
+          minimum: -90
+          maximum: 90
+          description: Target pan angle in degrees.
+        tilt_deg:
+          type: number
+          format: float
+          minimum: -45
+          maximum: 45
+          description: Target tilt angle in degrees.
+    PanTiltState:
+      type: object
+      required:
+        - pan_deg
+        - tilt_deg
+      properties:
+        pan_deg:
+          type: number
+          format: float
+        tilt_deg:
+          type: number
+          format: float
+    UltrasonicTelemetry:
+      type: object
+      required:
+        - distance_m
+        - valid
+        - history
+      properties:
+        distance_m:
+          type: number
+          format: float
+          description: Most recent measured distance in metres.
+        valid:
+          type: boolean
+          description: Whether the most recent reading passed outlier rejection.
+        history:
+          type: array
+          items:
+            type: object
+            required:
+              - distance_m
+              - valid
+            properties:
+              distance_m:
+                type: number
+                format: float
+              valid:
+                type: boolean
+          description: FIFO list of recent valid readings.
+    LineTelemetry:
+      type: object
+      required:
+        - left
+        - right
+        - on_line
+      properties:
+        left:
+          type: number
+          format: float
+          minimum: 0.0
+          maximum: 1.0
+        right:
+          type: number
+          format: float
+          minimum: 0.0
+          maximum: 1.0
+        on_line:
+          type: boolean
+          description: Whether either sensor currently detects the track.
+    ControlConfig:
+      type: object
+      required:
+        - ingress_rate_limit
+        - execution_rate_limit
+        - queue_maxsize
+        - allowed_networks
+      properties:
+        ingress_rate_limit:
+          type: object
+          required:
+            - rate_per_second
+            - burst
+          properties:
+            rate_per_second:
+              type: number
+              format: float
+              minimum: 0.1
+            burst:
+              type: integer
+              minimum: 1
+        execution_rate_limit:
+          type: object
+          required:
+            - rate_per_second
+            - burst
+          properties:
+            rate_per_second:
+              type: number
+              format: float
+              minimum: 0.1
+            burst:
+              type: integer
+              minimum: 1
+        queue_maxsize:
+          type: integer
+          minimum: 1
+        allowed_networks:
+          type: array
+          items:
+            type: string
+            format: ipv4
+            description: CIDR blocks permitted to access the API.
+paths:
+  /drive/differential:
+    post:
+      summary: Queue a differential-drive command
+      description: |
+        Adds a normalized left/right motor speed command to the execution queue. The
+        queue is drained by a worker that obeys the configured L293D-safe rate limit.
+      operationId: queueDifferentialDrive
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DifferentialDriveCommand'
+      responses:
+        '202':
+          description: Command accepted and queued for execution.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DriveQueueResponse'
+        '401':
+          description: Missing or invalid API key.
+        '403':
+          description: Client is not on an approved local network.
+        '429':
+          description: Command ingestion rate exceeded safe limit.
+  /drive/stop:
+    post:
+      summary: Coast both motors to a stop
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Motors commanded to coast.
+  /drive/brake:
+    post:
+      summary: Short the motors for an emergency brake
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Motors commanded to brake.
+  /drive/emergency-stop:
+    post:
+      summary: Engage the emergency stop latch
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Emergency stop engaged and queued commands cleared.
+  /drive/reset:
+    post:
+      summary: Reset the emergency stop latch
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Emergency stop cleared.
+  /pan-tilt/position:
+    post:
+      summary: Move the pan/tilt bracket to the requested angles
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PanTiltCommand'
+      responses:
+        '200':
+          description: Updated pan/tilt state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PanTiltState'
+  /telemetry/ultrasonic:
+    get:
+      summary: Fetch the latest ultrasonic range telemetry
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Latest filtered distance reading.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UltrasonicTelemetry'
+  /telemetry/line:
+    get:
+      summary: Fetch the latest line-follow sensor telemetry
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Current normalized reflectance readings.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LineTelemetry'
+  /config:
+    get:
+      summary: Retrieve the current control service configuration
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Current rate limiting and network configuration.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlConfig'
+    patch:
+      summary: Update mutable control configuration values
+      description: |
+        Allows adjusting rate limits and queue size during development. Production
+        systems should manage configuration through infrastructure tooling.
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ingress_rate_limit:
+                  $ref: '#/components/schemas/ControlConfig/properties/ingress_rate_limit'
+                execution_rate_limit:
+                  $ref: '#/components/schemas/ControlConfig/properties/execution_rate_limit'
+                queue_maxsize:
+                  type: integer
+                  minimum: 1
+      responses:
+        '200':
+          description: Updated configuration snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlConfig'
+---
+asyncapi: 2.6.0
+info:
+  title: Robby Control Telemetry Streams
+  version: 0.1.0
+  description: AsyncAPI definition for optional MQTT/WebSocket telemetry feeds.
+servers:
+  production:
+    url: mqtts://robby-control.local:8883
+    protocol: mqtt
+    description: Secure MQTT broker exposed on the local network.
+channels:
+  telemetry/ultrasonic:
+    subscribe:
+      summary: Subscribe to filtered ultrasonic telemetry events
+      message:
+        name: UltrasonicTelemetry
+        payload:
+          $ref: '#/components/schemas/UltrasonicTelemetry'
+  telemetry/line:
+    subscribe:
+      summary: Subscribe to line-follow sensor telemetry events
+      message:
+        name: LineTelemetry
+        payload:
+          $ref: '#/components/schemas/LineTelemetry'
+  control/estop:
+    publish:
+      summary: Broadcast emergency stop events to monitoring systems
+      message:
+        name: EmergencyStopEvent
+        payload:
+          type: object
+          required:
+            - engaged
+            - timestamp
+          properties:
+            engaged:
+              type: boolean
+            timestamp:
+              type: string
+              format: date-time
+components:
+  schemas:
+    UltrasonicTelemetry:
+      type: object
+      required:
+        - distance_m
+        - valid
+        - history
+      properties:
+        distance_m:
+          type: number
+          format: float
+        valid:
+          type: boolean
+        history:
+          type: array
+          items:
+            type: number
+            format: float
+    LineTelemetry:
+      type: object
+      required:
+        - left
+        - right
+        - on_line
+      properties:
+        left:
+          type: number
+          format: float
+        right:
+          type: number
+          format: float
+        on_line:
+          type: boolean

--- a/src/api/control_service/__init__.py
+++ b/src/api/control_service/__init__.py
@@ -1,0 +1,5 @@
+"""Public interface for the CamJam control service."""
+
+from .app import ControlServiceApp, ControlServiceConfig, RateLimitSettings, create_app
+
+__all__ = ["create_app", "ControlServiceApp", "ControlServiceConfig", "RateLimitSettings"]

--- a/src/api/control_service/app.py
+++ b/src/api/control_service/app.py
@@ -1,0 +1,255 @@
+"""Minimal control service application without external web frameworks."""
+
+from __future__ import annotations
+
+import ipaddress
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from .command_queue import CommandQueue, CommandQueueFullError, DriveCommand
+from .config import ControlServiceConfig, RateLimitSettings
+from .rate_limiter import TokenBucket
+
+
+@dataclass
+class Response:
+    """Lightweight HTTP-style response."""
+
+    status_code: int
+    body: Dict[str, Any]
+
+
+class ControlServiceApp:
+    """Application facade that mimics a small subset of FastAPI."""
+
+    def __init__(
+        self,
+        *,
+        config: ControlServiceConfig,
+        motor_controller: Any,
+        servo_controller: Any,
+        ultrasonic_ranger: Any,
+        line_follower: Any,
+    ) -> None:
+        self.config = config
+        self.motor_controller = motor_controller
+        self.servo_controller = servo_controller
+        self.ultrasonic_ranger = ultrasonic_ranger
+        self.line_follower = line_follower
+        self.ingress_limiter = TokenBucket(
+            rate_per_second=config.ingress_rate_limit.rate_per_second,
+            capacity=config.ingress_rate_limit.burst,
+        )
+        self.execution_limiter = TokenBucket(
+            rate_per_second=config.execution_rate_limit.rate_per_second,
+            capacity=config.execution_rate_limit.burst,
+        )
+        self.command_queue = CommandQueue(
+            motor_controller=motor_controller,
+            limiter=self.execution_limiter,
+            maxsize=config.queue_maxsize,
+        )
+        self._allowed_networks = [ipaddress.ip_network(net) for net in config.allowed_networks]
+        self._routes: Dict[Tuple[str, str], Any] = {
+            ("POST", "/drive/differential"): self._handle_drive,
+            ("POST", "/drive/stop"): self._handle_stop,
+            ("POST", "/drive/brake"): self._handle_brake,
+            ("POST", "/drive/emergency-stop"): self._handle_estop,
+            ("POST", "/drive/reset"): self._handle_reset,
+            ("POST", "/pan-tilt/position"): self._handle_pan_tilt,
+            ("GET", "/telemetry/ultrasonic"): self._handle_ultrasonic,
+            ("GET", "/telemetry/line"): self._handle_line,
+            ("GET", "/config"): self._handle_get_config,
+            ("PATCH", "/config"): self._handle_patch_config,
+        }
+
+    async def start(self) -> None:
+        await self.command_queue.start()
+
+    async def shutdown(self) -> None:
+        await self.command_queue.stop()
+        self.motor_controller.stop()
+        if hasattr(self.motor_controller, "close"):
+            self.motor_controller.close()
+
+    async def handle_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Response:
+        headers = headers or {}
+        auth_error = self._authenticate(headers)
+        if auth_error is not None:
+            return auth_error
+
+        route = self._routes.get((method.upper(), path))
+        if route is None:
+            return Response(status_code=404, body={"detail": "Not Found"})
+
+        try:
+            result = await route(json or {})
+        except ValueError as exc:
+            return Response(status_code=422, body={"detail": str(exc)})
+        return result
+
+    def _authenticate(self, headers: Dict[str, str]) -> Optional[Response]:
+        api_key = headers.get("X-Api-Key")
+        if api_key not in self.config.api_keys:
+            return Response(status_code=401, body={"detail": "Invalid API key"})
+
+        forwarded = headers.get("X-Forwarded-For")
+        client_ip = forwarded.split(",")[0].strip() if forwarded else "127.0.0.1"
+        try:
+            ip_obj = ipaddress.ip_address(client_ip)
+        except ValueError:
+            return Response(status_code=400, body={"detail": "Invalid client IP"})
+        if not any(ip_obj in network for network in self._allowed_networks):
+            return Response(status_code=403, body={"detail": "Client network not permitted"})
+        return None
+
+    async def _handle_drive(self, payload: Dict[str, Any]) -> Response:
+        left = self._validate_speed(payload.get("left_speed"), "left_speed")
+        right = self._validate_speed(payload.get("right_speed"), "right_speed")
+        duration = payload.get("duration_s")
+        if duration is not None:
+            if not isinstance(duration, (int, float)) or duration <= 0:
+                raise ValueError("duration_s must be a positive number")
+            duration_value = float(duration)
+        else:
+            duration_value = None
+
+        if not await self.ingress_limiter.allow():
+            return Response(status_code=429, body={"detail": "Command rate limit exceeded"})
+        try:
+            depth = await self.command_queue.enqueue_drive(
+                DriveCommand(left_speed=left, right_speed=right, duration_s=duration_value)
+            )
+        except CommandQueueFullError as exc:
+            return Response(status_code=503, body={"detail": str(exc)})
+        return Response(status_code=202, body={"status": "queued", "queue_depth": depth})
+
+    async def _handle_stop(self, payload: Dict[str, Any]) -> Response:
+        self.motor_controller.stop()
+        await self.command_queue.clear()
+        return Response(status_code=200, body={"status": "stopped"})
+
+    async def _handle_brake(self, payload: Dict[str, Any]) -> Response:
+        self.motor_controller.brake()
+        await self.command_queue.clear()
+        return Response(status_code=200, body={"status": "braking"})
+
+    async def _handle_estop(self, payload: Dict[str, Any]) -> Response:
+        await self.command_queue.clear()
+        self.motor_controller.emergency_stop()
+        return Response(status_code=200, body={"status": "estop"})
+
+    async def _handle_reset(self, payload: Dict[str, Any]) -> Response:
+        self.motor_controller.reset_estop()
+        return Response(status_code=200, body={"status": "ready"})
+
+    async def _handle_pan_tilt(self, payload: Dict[str, Any]) -> Response:
+        pan = payload.get("pan_deg")
+        tilt = payload.get("tilt_deg")
+        if not isinstance(pan, (int, float)) or not -90.0 <= float(pan) <= 90.0:
+            raise ValueError("pan_deg must be between -90 and 90 degrees")
+        if not isinstance(tilt, (int, float)) or not -45.0 <= float(tilt) <= 45.0:
+            raise ValueError("tilt_deg must be between -45 and 45 degrees")
+        self.servo_controller.move_to(float(pan), float(tilt))
+        return Response(
+            status_code=200,
+            body={"pan_deg": float(self.servo_controller.pan), "tilt_deg": float(self.servo_controller.tilt)},
+        )
+
+    async def _handle_ultrasonic(self, payload: Dict[str, Any]) -> Response:
+        reading = await self.ultrasonic_ranger.read()
+        history = []
+        for sample in getattr(self.ultrasonic_ranger, "history", []):
+            history.append({"distance_m": float(sample.distance_m), "valid": bool(sample.valid)})
+        return Response(
+            status_code=200,
+            body={
+                "distance_m": float(reading.distance_m),
+                "valid": bool(reading.valid),
+                "history": history,
+            },
+        )
+
+    async def _handle_line(self, payload: Dict[str, Any]) -> Response:
+        telemetry = await self.line_follower.read()
+        return Response(
+            status_code=200,
+            body={
+                "left": float(telemetry.left),
+                "right": float(telemetry.right),
+                "on_line": bool(telemetry.on_line),
+            },
+        )
+
+    async def _handle_get_config(self, payload: Dict[str, Any]) -> Response:
+        return Response(status_code=200, body=self.config.snapshot())
+
+    async def _handle_patch_config(self, payload: Dict[str, Any]) -> Response:
+        ingress = payload.get("ingress_rate_limit")
+        if ingress is not None:
+            self.config.ingress_rate_limit = RateLimitSettings(
+                rate_per_second=float(ingress["rate_per_second"]),
+                burst=int(ingress["burst"]),
+            )
+            self.ingress_limiter.configure(
+                rate_per_second=self.config.ingress_rate_limit.rate_per_second,
+                capacity=self.config.ingress_rate_limit.burst,
+            )
+        execution = payload.get("execution_rate_limit")
+        if execution is not None:
+            self.config.execution_rate_limit = RateLimitSettings(
+                rate_per_second=float(execution["rate_per_second"]),
+                burst=int(execution["burst"]),
+            )
+            self.execution_limiter.configure(
+                rate_per_second=self.config.execution_rate_limit.rate_per_second,
+                capacity=self.config.execution_rate_limit.burst,
+            )
+        queue_maxsize = payload.get("queue_maxsize")
+        if queue_maxsize is not None:
+            queue_value = int(queue_maxsize)
+            if queue_value <= 0:
+                raise ValueError("queue_maxsize must be positive")
+            self.config.queue_maxsize = queue_value
+            self.command_queue.set_maxsize(queue_value)
+        return Response(status_code=200, body=self.config.snapshot())
+
+    @staticmethod
+    def _validate_speed(value: Any, name: str) -> float:
+        if not isinstance(value, (int, float)):
+            raise ValueError(f"{name} is required")
+        float_value = float(value)
+        if float_value < -1.0 or float_value > 1.0:
+            raise ValueError(f"{name} must be between -1 and 1")
+        return float_value
+
+
+def create_app(
+    *,
+    config: Optional[ControlServiceConfig] = None,
+    motor_controller: Any = None,
+    servo_controller: Any = None,
+    ultrasonic_ranger: Any = None,
+    line_follower: Any = None,
+) -> ControlServiceApp:
+    if config is None:
+        config = ControlServiceConfig(api_keys={"local"})
+    if motor_controller is None or servo_controller is None or ultrasonic_ranger is None or line_follower is None:
+        raise RuntimeError("All hardware adapters must be provided explicitly in this environment")
+    return ControlServiceApp(
+        config=config,
+        motor_controller=motor_controller,
+        servo_controller=servo_controller,
+        ultrasonic_ranger=ultrasonic_ranger,
+        line_follower=line_follower,
+    )
+
+
+__all__ = ["create_app", "ControlServiceApp", "Response", "ControlServiceConfig", "RateLimitSettings"]

--- a/src/api/control_service/command_queue.py
+++ b/src/api/control_service/command_queue.py
@@ -1,0 +1,99 @@
+"""Asynchronous command queue for motor control."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Optional
+
+from .rate_limiter import TokenBucket
+
+
+@dataclass
+class DriveCommand:
+    left_speed: float
+    right_speed: float
+    duration_s: Optional[float] = None
+
+
+class CommandQueueFullError(RuntimeError):
+    """Raised when the command queue exceeds its configured capacity."""
+
+
+class CommandQueue:
+    """Background worker that executes drive commands sequentially."""
+
+    def __init__(
+        self,
+        *,
+        motor_controller,
+        limiter: TokenBucket,
+        maxsize: int,
+    ) -> None:
+        self._motor_controller = motor_controller
+        self._limiter = limiter
+        self._maxsize = maxsize
+        self._queue: asyncio.Queue[tuple[str, DriveCommand]] = asyncio.Queue()
+        self._worker_task: Optional[asyncio.Task[None]] = None
+        self._shutdown = asyncio.Event()
+
+    async def start(self) -> None:
+        if self._worker_task is None:
+            self._worker_task = asyncio.create_task(self._worker())
+
+    async def stop(self) -> None:
+        self._shutdown.set()
+        if self._worker_task is not None:
+            await self._worker_task
+            self._worker_task = None
+
+    async def enqueue_drive(self, command: DriveCommand) -> int:
+        if self._maxsize and self._queue.qsize() >= self._maxsize:
+            raise CommandQueueFullError("Drive command queue is full")
+        self._queue.put_nowait(("drive", command))
+        return self._queue.qsize()
+
+    async def clear(self) -> None:
+        while True:
+            try:
+                _ = self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            else:
+                self._queue.task_done()
+
+    async def wait_until_idle(self) -> None:
+        await self._queue.join()
+
+    def set_maxsize(self, maxsize: int) -> None:
+        if maxsize <= 0:
+            raise ValueError("maxsize must be positive")
+        self._maxsize = maxsize
+
+    async def _worker(self) -> None:
+        try:
+            while True:
+                if self._shutdown.is_set() and self._queue.empty():
+                    break
+                try:
+                    item_type, command = await asyncio.wait_for(self._queue.get(), timeout=0.1)
+                except asyncio.TimeoutError:
+                    continue
+                try:
+                    if item_type == "drive":
+                        await self._limiter.wait_for_token()
+                        self._motor_controller.drive(command.left_speed, command.right_speed)
+                        if command.duration_s:
+                            await asyncio.sleep(command.duration_s)
+                            self._motor_controller.stop()
+                finally:
+                    self._queue.task_done()
+        finally:
+            # Drain remaining items to avoid pending join() callers hanging.
+            while not self._queue.empty():
+                try:
+                    self._queue.get_nowait()
+                except asyncio.QueueEmpty:  # pragma: no cover - race guard
+                    break
+                else:
+                    self._queue.task_done()

--- a/src/api/control_service/config.py
+++ b/src/api/control_service/config.py
@@ -1,0 +1,58 @@
+"""Configuration structures for the control service API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Set
+
+
+@dataclass
+class RateLimitSettings:
+    """Token-bucket parameters for rate limiting."""
+
+    rate_per_second: float
+    burst: int
+
+    def __post_init__(self) -> None:
+        if self.rate_per_second <= 0:
+            raise ValueError("rate_per_second must be positive")
+        if self.burst <= 0:
+            raise ValueError("burst must be a positive integer")
+
+
+@dataclass
+class ControlServiceConfig:
+    """Runtime configuration for the API."""
+
+    api_keys: Set[str] = field(default_factory=set)
+    allowed_networks: Iterable[str] = field(default_factory=lambda: ("127.0.0.0/8",))
+    ingress_rate_limit: RateLimitSettings = field(
+        default_factory=lambda: RateLimitSettings(rate_per_second=5.0, burst=5)
+    )
+    execution_rate_limit: RateLimitSettings = field(
+        default_factory=lambda: RateLimitSettings(rate_per_second=10.0, burst=5)
+    )
+    queue_maxsize: int = 32
+
+    def __post_init__(self) -> None:
+        if self.queue_maxsize <= 0:
+            raise ValueError("queue_maxsize must be positive")
+        if not self.api_keys:
+            raise ValueError("At least one API key must be configured")
+        self.allowed_networks = tuple(self.allowed_networks)
+
+    def snapshot(self) -> dict[str, object]:
+        """Return a serialisable copy of the configuration."""
+
+        return {
+            "ingress_rate_limit": {
+                "rate_per_second": self.ingress_rate_limit.rate_per_second,
+                "burst": self.ingress_rate_limit.burst,
+            },
+            "execution_rate_limit": {
+                "rate_per_second": self.execution_rate_limit.rate_per_second,
+                "burst": self.execution_rate_limit.burst,
+            },
+            "queue_maxsize": self.queue_maxsize,
+            "allowed_networks": list(self.allowed_networks),
+        }

--- a/src/api/control_service/rate_limiter.py
+++ b/src/api/control_service/rate_limiter.py
@@ -1,0 +1,66 @@
+"""Token bucket rate limiter utilities."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class TokenBucketState:
+    rate_per_second: float
+    capacity: int
+
+
+class TokenBucket:
+    """Asynchronous token bucket implementation."""
+
+    def __init__(self, *, rate_per_second: float, capacity: int) -> None:
+        self._state = TokenBucketState(rate_per_second=rate_per_second, capacity=capacity)
+        self._tokens = float(capacity)
+        self._updated_at = time.monotonic()
+        self._lock = asyncio.Lock()
+
+    def configure(self, *, rate_per_second: float, capacity: int) -> None:
+        """Update the limiter parameters."""
+
+        if rate_per_second <= 0:
+            raise ValueError("rate_per_second must be positive")
+        if capacity <= 0:
+            raise ValueError("capacity must be positive")
+        self._state = TokenBucketState(rate_per_second=rate_per_second, capacity=capacity)
+
+    async def allow(self) -> bool:
+        """Attempt to consume a token without blocking."""
+
+        async with self._lock:
+            self._refill()
+            if self._tokens >= 1.0:
+                self._tokens -= 1.0
+                return True
+            return False
+
+    async def wait_for_token(self) -> None:
+        """Block until a token is available and consume it."""
+
+        while True:
+            async with self._lock:
+                self._refill()
+                if self._tokens >= 1.0:
+                    self._tokens -= 1.0
+                    return
+                deficit = max(0.0, 1.0 - self._tokens)
+                wait_time = deficit / self._state.rate_per_second if self._state.rate_per_second > 0 else 0.1
+            await asyncio.sleep(wait_time)
+
+    def _refill(self) -> None:
+        now = time.monotonic()
+        elapsed = max(0.0, now - self._updated_at)
+        if elapsed <= 0:
+            return
+        self._tokens = min(
+            float(self._state.capacity),
+            self._tokens + elapsed * self._state.rate_per_second,
+        )
+        self._updated_at = now

--- a/tests/api/test_control_service_camjam.py
+++ b/tests/api/test_control_service_camjam.py
@@ -1,0 +1,235 @@
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from src.api.control_service import (
+    ControlServiceConfig,
+    ControlServiceApp,
+    RateLimitSettings,
+    create_app,
+)
+
+
+class StubMotorController:
+    def __init__(self) -> None:
+        self.commands: List[Tuple[str, Tuple[Any, ...]]] = []
+        self.estopped = False
+
+    def drive(self, left: float, right: float) -> None:
+        self.commands.append(("drive", (left, right, time.monotonic())))
+
+    def stop(self) -> None:
+        self.commands.append(("stop", tuple()))
+
+    def brake(self) -> None:
+        self.commands.append(("brake", tuple()))
+
+    def emergency_stop(self) -> None:
+        self.estopped = True
+        self.commands.append(("estop", tuple()))
+
+    def reset_estop(self) -> None:
+        self.estopped = False
+        self.commands.append(("reset", tuple()))
+
+
+class StubServoController:
+    def __init__(self) -> None:
+        self.pan = 0.0
+        self.tilt = 0.0
+
+    def move_to(self, pan: float, tilt: float) -> None:
+        self.pan = pan
+        self.tilt = tilt
+
+
+@dataclass
+class StubUltrasonicReading:
+    distance_m: float
+    valid: bool
+
+
+class StubUltrasonicRanger:
+    def __init__(self) -> None:
+        self._history: List[StubUltrasonicReading] = []
+
+    @property
+    def history(self) -> List[StubUltrasonicReading]:
+        return self._history
+
+    async def read(self) -> StubUltrasonicReading:
+        reading = StubUltrasonicReading(distance_m=0.42, valid=True)
+        self._history.append(reading)
+        return reading
+
+
+@dataclass
+class StubLineTelemetry:
+    left: float
+    right: float
+    on_line: bool
+
+
+class StubLineFollower:
+    async def read(self) -> StubLineTelemetry:
+        return StubLineTelemetry(left=0.7, right=0.3, on_line=True)
+
+
+@pytest.fixture
+def control_app() -> Tuple[ControlServiceApp, Dict[str, Any], asyncio.AbstractEventLoop]:
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    motor = StubMotorController()
+    servos = StubServoController()
+    ultrasonic = StubUltrasonicRanger()
+    line = StubLineFollower()
+
+    config = ControlServiceConfig(
+        api_keys={"test-key"},
+        allowed_networks=["127.0.0.0/8"],
+        ingress_rate_limit=RateLimitSettings(rate_per_second=10.0, burst=5),
+        execution_rate_limit=RateLimitSettings(rate_per_second=50.0, burst=5),
+        queue_maxsize=16,
+    )
+
+    app = create_app(
+        config=config,
+        motor_controller=motor,
+        servo_controller=servos,
+        ultrasonic_ranger=ultrasonic,
+        line_follower=line,
+    )
+
+    loop.run_until_complete(app.start())
+
+    context = {
+        "motor": motor,
+        "servos": servos,
+        "ultrasonic": ultrasonic,
+        "line": line,
+    }
+
+    yield app, context, loop
+
+    loop.run_until_complete(app.shutdown())
+    loop.run_until_complete(loop.shutdown_asyncgens())
+    loop.close()
+    asyncio.set_event_loop(None)
+
+
+def test_rejects_invalid_drive_payload(control_app) -> None:
+    app, _, loop = control_app
+    response = loop.run_until_complete(
+        app.handle_request(
+            "POST",
+            "/drive/differential",
+            json={"left_speed": 1.5, "right_speed": 0.2},
+            headers={"X-Api-Key": "test-key"},
+        )
+    )
+    assert response.status_code == 422
+
+
+def test_rejects_remote_clients(control_app) -> None:
+    app, _, loop = control_app
+    response = loop.run_until_complete(
+        app.handle_request(
+            "POST",
+            "/drive/stop",
+            headers={
+                "X-Api-Key": "test-key",
+                "X-Forwarded-For": "8.8.8.8",
+            },
+        )
+    )
+    assert response.status_code == 403
+
+
+def test_rate_limit_enforced(control_app) -> None:
+    app, _, loop = control_app
+    app.config.ingress_rate_limit = RateLimitSettings(rate_per_second=2.0, burst=2)
+    app.ingress_limiter.configure(rate_per_second=2.0, capacity=2)
+    headers = {"X-Api-Key": "test-key"}
+    status_codes = []
+    for _ in range(4):
+        response = loop.run_until_complete(
+            app.handle_request(
+                "POST",
+                "/drive/differential",
+                json={"left_speed": 0.2, "right_speed": 0.2},
+                headers=headers,
+            )
+        )
+        status_codes.append(response.status_code)
+    assert 429 in status_codes
+
+
+def test_drive_commands_processed_sequentially(control_app) -> None:
+    app, context, loop = control_app
+    headers = {"X-Api-Key": "test-key"}
+    commands = [
+        {"left_speed": 0.1, "right_speed": 0.2},
+        {"left_speed": -0.3, "right_speed": -0.4},
+        {"left_speed": 0.5, "right_speed": -0.1},
+    ]
+
+    for payload in commands:
+        response = loop.run_until_complete(
+            app.handle_request("POST", "/drive/differential", json=payload, headers=headers)
+        )
+        assert response.status_code == 202
+
+    loop.run_until_complete(asyncio.wait_for(app.command_queue.wait_until_idle(), timeout=2.0))
+
+    drive_commands = [cmd for cmd in context["motor"].commands if cmd[0] == "drive"]
+    assert len(drive_commands) == len(commands)
+    executed_pairs = [(entry[1][0], entry[1][1]) for entry in drive_commands]
+    assert executed_pairs == [(c["left_speed"], c["right_speed"]) for c in commands]
+    timestamps = [entry[1][2] for entry in drive_commands]
+    assert timestamps == sorted(timestamps)
+
+
+def test_servo_command_validation(control_app) -> None:
+    app, _, loop = control_app
+    response = loop.run_until_complete(
+        app.handle_request(
+            "POST",
+            "/pan-tilt/position",
+            json={"pan_deg": 120, "tilt_deg": 10},
+            headers={"X-Api-Key": "test-key"},
+        )
+    )
+    assert response.status_code == 422
+
+
+def test_ultrasonic_schema(control_app) -> None:
+    app, _, loop = control_app
+    response = loop.run_until_complete(
+        app.handle_request(
+            "GET",
+            "/telemetry/ultrasonic",
+            headers={"X-Api-Key": "test-key"},
+        )
+    )
+    data = response.body
+    assert response.status_code == 200
+    assert data["distance_m"] == pytest.approx(0.42)
+    assert data["valid"] is True
+    assert isinstance(data["history"], list)
+
+
+def test_line_schema(control_app) -> None:
+    app, _, loop = control_app
+    response = loop.run_until_complete(
+        app.handle_request(
+            "GET",
+            "/telemetry/line",
+            headers={"X-Api-Key": "test-key"},
+        )
+    )
+    assert response.status_code == 200
+    assert response.body == {"left": 0.7, "right": 0.3, "on_line": True}


### PR DESCRIPTION
## Summary
- document the control service REST and telemetry contracts in a combined OpenAPI/AsyncAPI specification
- implement a minimal control service façade with rate limiting, queueing, and hardware adapter integration
- add contract tests covering payload validation, ingress throttling, queue ordering, and local network access control

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d980acf824832f8ece44f85ede8c7a