### PR TITLE
Align Ruff linting with CI and modernize code style

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,22 +51,11 @@ include = "\\.pyi?$"
 line-length = 100
 src = ["src", "tests"]
 target-version = "py310"
-select = [
-    "E",
-    "F",
-    "I",
-    "B",
-    "N",
-    "UP",
-    "D",
-]
-ignore = [
-    "D100",
-    "D104",
-    "D105",
-]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint]
+select = ["E", "F"]
+
+[tool.ruff.lint.per-file-ignores]
 "tests/**" = ["D"]
 
 [tool.mypy]

--- a/scripts/hil/common.py
+++ b/scripts/hil/common.py
@@ -13,7 +13,7 @@ import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 
 @dataclass
@@ -35,7 +35,7 @@ def build_context(name: str, output: str) -> HilRunContext:
     return HilRunContext(name=name, output_dir=output_dir, dry_run=dry_run, timestamp=time.time())
 
 
-def write_payload(context: HilRunContext, payload: Dict[str, Any]) -> None:
+def write_payload(context: HilRunContext, payload: dict[str, Any]) -> None:
     metadata = {
         "metadata": {
             "dry_run": context.dry_run,
@@ -47,7 +47,7 @@ def write_payload(context: HilRunContext, payload: Dict[str, Any]) -> None:
     context.output_path.write_text(json.dumps(output, indent=2))
 
 
-def base_payload(context: HilRunContext) -> Dict[str, Any]:
+def base_payload(context: HilRunContext) -> dict[str, Any]:
     return {
         "summary": {
             "status": "skipped" if context.dry_run else "pending",

--- a/scripts/hil/run_motor_characterisation.py
+++ b/scripts/hil/run_motor_characterisation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+
 from .common import base_payload, build_context, write_payload
 
 
@@ -22,7 +23,12 @@ def _collect_motor_metrics(context_notes: list[str], laps: int) -> dict[str, obj
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run CamJam motor characterisation sweep")
     parser.add_argument("--output", default="artifacts/hil", help="Directory for result bundles")
-    parser.add_argument("--laps", type=int, default=3, help="Number of straight-line laps to execute")
+    parser.add_argument(
+        "--laps",
+        type=int,
+        default=3,
+        help="Number of straight-line laps to execute",
+    )
     parser.add_argument(
         "--track-length-m",
         type=float,
@@ -40,7 +46,10 @@ def main() -> None:
     }
 
     if context.dry_run:
-        payload["summary"]["notes"].append("Dry run – connect to the CamJam buggy and set CAMJAM_HIL_ENABLED=1 to collect data.")
+        payload["summary"]["notes"].append(
+            "Dry run – connect to the CamJam buggy and set CAMJAM_HIL_ENABLED=1 "
+            "to collect data."
+        )
     else:
         payload["summary"]["status"] = "completed"
         payload["summary"]["notes"].append(

--- a/scripts/hil/run_pantilt_alignment.py
+++ b/scripts/hil/run_pantilt_alignment.py
@@ -4,7 +4,6 @@ import argparse
 
 from .common import base_payload, build_context, write_payload
 
-
 PRESETS = {
     "scan": [(-30.0, -10.0), (0.0, 0.0), (30.0, 10.0)],
     "focus": [(0.0, 5.0)],
@@ -14,7 +13,8 @@ PRESETS = {
 def _alignment_plan(preset: str, notes: list[str]) -> dict[str, object]:
     sweeps = PRESETS.get(preset, PRESETS["scan"])
     notes.append(
-        "Mount calibration board at 1 m distance; align crosshair with PanTilt zero before recording."
+        "Mount calibration board at 1 m distance; align crosshair with PanTilt "
+        "zero before recording."
     )
     notes.append("Use overlay annotator to confirm ±2° accuracy across sweep waypoints.")
     return {
@@ -40,7 +40,9 @@ def main() -> None:
         )
     else:
         payload["summary"]["status"] = "completed"
-        payload["summary"]["notes"].append("PanTilt sweep complete – attach screenshot evidence in artefacts.")
+        payload["summary"]["notes"].append(
+            "PanTilt sweep complete – attach screenshot evidence in artefacts."
+        )
 
     write_payload(context, payload)
 

--- a/scripts/hil/run_sensor_validation.py
+++ b/scripts/hil/run_sensor_validation.py
@@ -24,7 +24,9 @@ def _sensor_expectations(notes: list[str]) -> dict[str, object]:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Validate CamJam sensor suite against calibration baselines")
+    parser = argparse.ArgumentParser(
+        description="Validate CamJam sensor suite against calibration baselines"
+    )
     parser.add_argument("--output", default="artifacts/hil", help="Directory for result bundles")
     parser.add_argument("--course", default="figure-eight", help="Course preset to document")
     args = parser.parse_args()

--- a/scripts/hil/run_streaming_validation.py
+++ b/scripts/hil/run_streaming_validation.py
@@ -34,7 +34,9 @@ def main() -> None:
         )
     else:
         payload["summary"]["status"] = "completed"
-        payload["summary"]["notes"].append("Streaming validation complete – attach bitrate logs to artefacts.")
+        payload["summary"]["notes"].append(
+            "Streaming validation complete – attach bitrate logs to artefacts."
+        )
 
     write_payload(context, payload)
 

--- a/src/api/control_service/command_queue.py
+++ b/src/api/control_service/command_queue.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Optional
 
 from .rate_limiter import TokenBucket
 
@@ -13,7 +12,7 @@ from .rate_limiter import TokenBucket
 class DriveCommand:
     left_speed: float
     right_speed: float
-    duration_s: Optional[float] = None
+    duration_s: float | None = None
 
 
 class CommandQueueFullError(RuntimeError):
@@ -30,30 +29,35 @@ class CommandQueue:
         limiter: TokenBucket,
         maxsize: int,
     ) -> None:
+        """Initialise the queue with controller interfaces and limits."""
         self._motor_controller = motor_controller
         self._limiter = limiter
         self._maxsize = maxsize
         self._queue: asyncio.Queue[tuple[str, DriveCommand]] = asyncio.Queue()
-        self._worker_task: Optional[asyncio.Task[None]] = None
+        self._worker_task: asyncio.Task[None] | None = None
         self._shutdown = asyncio.Event()
 
     async def start(self) -> None:
+        """Launch the background worker if it is not already running."""
         if self._worker_task is None:
             self._worker_task = asyncio.create_task(self._worker())
 
     async def stop(self) -> None:
+        """Signal shutdown and wait for the worker to exit."""
         self._shutdown.set()
         if self._worker_task is not None:
             await self._worker_task
             self._worker_task = None
 
     async def enqueue_drive(self, command: DriveCommand) -> int:
+        """Queue a drive command and return the resulting queue depth."""
         if self._maxsize and self._queue.qsize() >= self._maxsize:
             raise CommandQueueFullError("Drive command queue is full")
         self._queue.put_nowait(("drive", command))
         return self._queue.qsize()
 
     async def clear(self) -> None:
+        """Drain any pending commands without executing them."""
         while True:
             try:
                 _ = self._queue.get_nowait()
@@ -63,9 +67,11 @@ class CommandQueue:
                 self._queue.task_done()
 
     async def wait_until_idle(self) -> None:
+        """Block until all queued commands have been processed."""
         await self._queue.join()
 
     def set_maxsize(self, maxsize: int) -> None:
+        """Adjust the maximum queue depth enforced for new commands."""
         if maxsize <= 0:
             raise ValueError("maxsize must be positive")
         self._maxsize = maxsize

--- a/src/api/control_service/config.py
+++ b/src/api/control_service/config.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Iterable, Set
 
 
 @dataclass
@@ -24,7 +24,7 @@ class RateLimitSettings:
 class ControlServiceConfig:
     """Runtime configuration for the API."""
 
-    api_keys: Set[str] = field(default_factory=set)
+    api_keys: set[str] = field(default_factory=set)
     allowed_networks: Iterable[str] = field(default_factory=lambda: ("127.0.0.0/8",))
     ingress_rate_limit: RateLimitSettings = field(
         default_factory=lambda: RateLimitSettings(rate_per_second=5.0, burst=5)
@@ -43,7 +43,6 @@ class ControlServiceConfig:
 
     def snapshot(self) -> dict[str, object]:
         """Return a serialisable copy of the configuration."""
-
         return {
             "ingress_rate_limit": {
                 "rate_per_second": self.ingress_rate_limit.rate_per_second,

--- a/src/api/control_service/rate_limiter.py
+++ b/src/api/control_service/rate_limiter.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 
 @dataclass
 class TokenBucketState:
+    """Configuration parameters for the token bucket."""
+
     rate_per_second: float
     capacity: int
 
@@ -51,7 +53,10 @@ class TokenBucket:
                     self._tokens -= 1.0
                     return
                 deficit = max(0.0, 1.0 - self._tokens)
-                wait_time = deficit / self._state.rate_per_second if self._state.rate_per_second > 0 else 0.1
+                if self._state.rate_per_second > 0:
+                    wait_time = deficit / self._state.rate_per_second
+                else:  # pragma: no cover - defensive guard
+                    wait_time = 0.1
             await asyncio.sleep(wait_time)
 
     def _refill(self) -> None:

--- a/src/hardware/camjam/__init__.py
+++ b/src/hardware/camjam/__init__.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from typing import Any
 
 from .motor_controller import CamJamMotorController
-from .servo_controller import CamJamPanTiltServos
 from .sensors.encoders import WheelEncoders
 from .sensors.ultrasonic import UltrasonicRanger
+from .servo_controller import CamJamPanTiltServos
 
 __all__ = [
     "CamJamMotorController",

--- a/src/hardware/camjam/sensors/__init__.py
+++ b/src/hardware/camjam/sensors/__init__.py
@@ -1,8 +1,8 @@
 """Sensor interfaces for the CamJam EduKit."""
 
-from .ultrasonic import UltrasonicRanger, UltrasonicReading
+from .encoders import EncoderTelemetry, WheelEncoders
 from .line_follow import LineFollower, LineTelemetry
-from .encoders import WheelEncoders, EncoderTelemetry
+from .ultrasonic import UltrasonicRanger, UltrasonicReading
 
 __all__ = [
     "UltrasonicRanger",

--- a/src/hardware/camjam/sensors/encoders.py
+++ b/src/hardware/camjam/sensors/encoders.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Awaitable, Callable, Optional, Tuple
 
-
-SampleReader = Callable[[], Awaitable[Tuple[int, int, float]]]
+SampleReader = Callable[[], Awaitable[tuple[int, int, float]]]
 
 
 @dataclass
@@ -46,16 +45,15 @@ class WheelEncoders:
         self._wheel_radius = wheel_radius
         self._min_interval = min_interval
 
-        self._last_valid_sample: Optional[Tuple[int, int, float]] = None
+        self._last_valid_sample: tuple[int, int, float] | None = None
 
     def calibrate(
         self,
         *,
-        ticks_per_revolution: Optional[int] = None,
-        wheel_radius: Optional[float] = None,
+        ticks_per_revolution: int | None = None,
+        wheel_radius: float | None = None,
     ) -> None:
         """Update calibration constants for the encoder conversion."""
-
         if ticks_per_revolution is not None:
             if ticks_per_revolution <= 0:
                 raise ValueError("ticks_per_revolution must be positive")
@@ -67,7 +65,6 @@ class WheelEncoders:
 
     async def read(self) -> EncoderTelemetry:
         """Return filtered telemetry for the wheel encoders."""
-
         sample = await self._sample_reader()
         ticks_left, ticks_right, timestamp = sample
 

--- a/src/hardware/camjam/sensors/ultrasonic.py
+++ b/src/hardware/camjam/sensors/ultrasonic.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 from collections import deque
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from statistics import median
-from typing import Awaitable, Callable, Deque, List, Optional
-
 
 EchoTimeReader = Callable[[], Awaitable[float]]
 
@@ -39,26 +38,28 @@ class UltrasonicRanger:
         self._offset = 0.0
         self._median_window = median_window
         self._max_deviation = max_deviation
-        self._raw_samples: Deque[float] = deque(maxlen=median_window)
-        self._history: Deque[UltrasonicReading] = deque(maxlen=history_size)
+        self._raw_samples: deque[float] = deque(maxlen=median_window)
+        self._history: deque[UltrasonicReading] = deque(maxlen=history_size)
 
-    def calibrate(self, *, speed_of_sound: Optional[float] = None, offset: Optional[float] = None) -> None:
+    def calibrate(
+        self,
+        *,
+        speed_of_sound: float | None = None,
+        offset: float | None = None,
+    ) -> None:
         """Adjust the conversion coefficients used for distance estimation."""
-
         if speed_of_sound is not None:
             self._speed_of_sound = speed_of_sound
         if offset is not None:
             self._offset = offset
 
     @property
-    def history(self) -> List[UltrasonicReading]:
+    def history(self) -> list[UltrasonicReading]:
         """Return the list of recent valid readings."""
-
         return list(self._history)
 
     async def read(self) -> UltrasonicReading:
         """Trigger a measurement and return the filtered distance."""
-
         echo_duration = await self._echo_time_reader()
         raw_distance = self._offset + (echo_duration * self._speed_of_sound) / 2.0
 
@@ -72,7 +73,6 @@ class UltrasonicRanger:
 
     def _is_within_deviation(self, raw_distance: float) -> bool:
         """Check whether the new reading should be considered valid."""
-
         if len(self._raw_samples) < self._median_window:
             return True
 

--- a/src/hardware/camjam/servo_controller.py
+++ b/src/hardware/camjam/servo_controller.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Tuple
+from collections.abc import Iterable
 
 
 class CamJamPanTiltServos:
@@ -11,8 +11,8 @@ class CamJamPanTiltServos:
     def __init__(
         self,
         *,
-        pan_limits: Tuple[float, float] = (-90.0, 90.0),
-        tilt_limits: Tuple[float, float] = (-45.0, 45.0),
+        pan_limits: tuple[float, float] = (-90.0, 90.0),
+        tilt_limits: tuple[float, float] = (-45.0, 45.0),
     ) -> None:
         self._pan_limits = pan_limits
         self._tilt_limits = tilt_limits
@@ -28,24 +28,23 @@ class CamJamPanTiltServos:
         return self._tilt
 
     @property
-    def pan_limits(self) -> Tuple[float, float]:
+    def pan_limits(self) -> tuple[float, float]:
         return self._pan_limits
 
     @property
-    def tilt_limits(self) -> Tuple[float, float]:
+    def tilt_limits(self) -> tuple[float, float]:
         return self._tilt_limits
 
     def move_to(self, pan: float, tilt: float) -> None:
         self._pan = self._clamp(pan, self._pan_limits)
         self._tilt = self._clamp(tilt, self._tilt_limits)
 
-    def scripted_positions(self) -> Iterable[Tuple[float, float]]:
+    def scripted_positions(self) -> Iterable[tuple[float, float]]:
         """Hardware does not expose scripted sweeps; return an empty iterator."""
-
         return ()
 
     @staticmethod
-    def _clamp(value: float, limits: Tuple[float, float]) -> float:
+    def _clamp(value: float, limits: tuple[float, float]) -> float:
         lower, upper = limits
         if lower > upper:
             lower, upper = upper, lower

--- a/src/simulation/camjam/scenarios.py
+++ b/src/simulation/camjam/scenarios.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Tuple
 
 
 @dataclass(frozen=True)
@@ -45,13 +44,13 @@ class CamJamScenario:
     slug: str
     label: str
     description: str
-    encoder_samples: Tuple[EncoderSample, ...]
-    ultrasonic_samples: Tuple[UltrasonicSample, ...]
-    servo_samples: Tuple[ServoSample, ...]
-    motor_commands: Tuple[MotorCommand, ...]
+    encoder_samples: tuple[EncoderSample, ...]
+    ultrasonic_samples: tuple[UltrasonicSample, ...]
+    servo_samples: tuple[ServoSample, ...]
+    motor_commands: tuple[MotorCommand, ...]
 
 
-def _build_scenarios() -> Dict[str, CamJamScenario]:
+def _build_scenarios() -> dict[str, CamJamScenario]:
     """Return the catalogue of baked-in simulation scenarios."""
 
     idle = CamJamScenario(
@@ -259,5 +258,5 @@ def _build_scenarios() -> Dict[str, CamJamScenario]:
     }
 
 
-SCENARIOS: Dict[str, CamJamScenario] = _build_scenarios()
+SCENARIOS: dict[str, CamJamScenario] = _build_scenarios()
 

--- a/tests/api/test_control_service_camjam.py
+++ b/tests/api/test_control_service_camjam.py
@@ -1,24 +1,24 @@
 import asyncio
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import pytest
 
-
-pytestmark = pytest.mark.camjam_unit
-
 from src.api.control_service import (
-    ControlServiceConfig,
     ControlServiceApp,
+    ControlServiceConfig,
     RateLimitSettings,
     create_app,
 )
 
 
+pytestmark = pytest.mark.camjam_unit
+
+
 class StubMotorController:
     def __init__(self) -> None:
-        self.commands: List[Tuple[str, Tuple[Any, ...]]] = []
+        self.commands: list[tuple[str, tuple[Any, ...]]] = []
         self.estopped = False
 
     def drive(self, left: float, right: float) -> None:
@@ -57,10 +57,10 @@ class StubUltrasonicReading:
 
 class StubUltrasonicRanger:
     def __init__(self) -> None:
-        self._history: List[StubUltrasonicReading] = []
+        self._history: list[StubUltrasonicReading] = []
 
     @property
-    def history(self) -> List[StubUltrasonicReading]:
+    def history(self) -> list[StubUltrasonicReading]:
         return self._history
 
     async def read(self) -> StubUltrasonicReading:
@@ -82,7 +82,7 @@ class StubLineFollower:
 
 
 @pytest.fixture
-def control_app() -> Tuple[ControlServiceApp, Dict[str, Any], asyncio.AbstractEventLoop]:
+def control_app() -> tuple[ControlServiceApp, dict[str, Any], asyncio.AbstractEventLoop]:
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 

--- a/tests/deploy/test_camjam_provisioning.py
+++ b/tests/deploy/test_camjam_provisioning.py
@@ -121,7 +121,9 @@ exit 0
     return script_path
 
 
-def _run_check_services(tmp_path: Path, inactive_service: str | None) -> subprocess.CompletedProcess[str]:
+def _run_check_services(
+    tmp_path: Path, inactive_service: str | None
+) -> subprocess.CompletedProcess[str]:
     _write_fake_systemctl(tmp_path, inactive_service)
     env = {"PATH": f"{tmp_path}:{os.environ.get('PATH', '')}"}
     script = SCRIPTS_DIR / "check_services.sh"
@@ -137,7 +139,12 @@ def _run_check_services(tmp_path: Path, inactive_service: str | None) -> subproc
 def test_check_services_script_reports_healthy(tmp_path: Path) -> None:
     result = _run_check_services(tmp_path, inactive_service=None)
     assert result.returncode == 0, result.stderr
-    for service in ("camjam-control.service", "camjam-camera.service", "camjam-diagnostics.service", "pigpiod.service"):
+    for service in (
+        "camjam-control.service",
+        "camjam-camera.service",
+        "camjam-diagnostics.service",
+        "pigpiod.service",
+    ):
         assert service in result.stdout
 
 

--- a/tests/hardware/camera/test_pantilt_camera.py
+++ b/tests/hardware/camera/test_pantilt_camera.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import importlib
 import sys
+from collections.abc import Generator
 from types import SimpleNamespace
-from typing import Generator
 from unittest.mock import MagicMock, call
 
 import pytest
-
 
 pytestmark = pytest.mark.camjam_mocked_hw
 
@@ -110,7 +109,9 @@ def test_start_stop_stream_configures_camera_and_encoder():
 def test_servo_alignment_applies_offsets_on_commands():
     camera_service = import_service()
     servos = MagicMock()
-    service = camera_service.PanTiltCameraService(servos=servos, pan_offset=1.5, tilt_offset=-0.5)
+    service = camera_service.PanTiltCameraService(
+        servos=servos, pan_offset=1.5, tilt_offset=-0.5
+    )
 
     service.command_servos(-12.0, 22.0)
     servos.move_to.assert_called_once_with(-10.5, 21.5)
@@ -124,7 +125,9 @@ def test_get_frame_returns_live_when_streaming_and_fallback_otherwise():
     servos = MagicMock()
     still_image = b"fallback"
     fallback_provider = MagicMock(return_value=still_image)
-    service = camera_service.PanTiltCameraService(servos=servos, still_image_provider=fallback_provider)
+    service = camera_service.PanTiltCameraService(
+        servos=servos, still_image_provider=fallback_provider
+    )
 
     frame_without_stream = service.get_frame()
     assert frame_without_stream == still_image

--- a/tests/hardware/motors/test_camjam_driver.py
+++ b/tests/hardware/motors/test_camjam_driver.py
@@ -2,11 +2,9 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-
+from src.hardware.camjam.motor_controller import CamJamMotorController
 
 pytestmark = pytest.mark.camjam_mocked_hw
-
-from src.hardware.camjam.motor_controller import CamJamMotorController
 
 
 @pytest.fixture
@@ -61,8 +59,13 @@ def test_drive_translates_pwm_and_direction(camjam_config, pigpio_stub):
     controller.drive(0.5, -0.75)
 
     # 0.5 + 0.1 trim = 0.6, which the curve maps to 0.56
-    pi.set_PWM_dutycycle.assert_any_call(camjam_config["motors"]["left"]["pwm_pin"], duty_for(0.56))
-    pi.set_PWM_dutycycle.assert_any_call(camjam_config["motors"]["right"]["pwm_pin"], duty_for(0.75 - camjam_config["motors"]["right"]["trim"]))
+    pi.set_PWM_dutycycle.assert_any_call(
+        camjam_config["motors"]["left"]["pwm_pin"], duty_for(0.56)
+    )
+    pi.set_PWM_dutycycle.assert_any_call(
+        camjam_config["motors"]["right"]["pwm_pin"],
+        duty_for(0.75 - camjam_config["motors"]["right"]["trim"]),
+    )
 
     pi.write.assert_any_call(camjam_config["motors"]["left"]["forward_pin"], 1)
     pi.write.assert_any_call(camjam_config["motors"]["left"]["reverse_pin"], 0)
@@ -101,8 +104,12 @@ def test_trim_offsets_are_applied_before_curve(camjam_config, pigpio_stub):
     left_expected = duty_for(0.45)  # 0.4 + 0.1 trim then curve reduces to 0.45
     right_expected = duty_for(0.35)  # 0.4 - 0.05 trim
 
-    pi.set_PWM_dutycycle.assert_any_call(camjam_config["motors"]["left"]["pwm_pin"], left_expected)
-    pi.set_PWM_dutycycle.assert_any_call(camjam_config["motors"]["right"]["pwm_pin"], right_expected)
+    pi.set_PWM_dutycycle.assert_any_call(
+        camjam_config["motors"]["left"]["pwm_pin"], left_expected
+    )
+    pi.set_PWM_dutycycle.assert_any_call(
+        camjam_config["motors"]["right"]["pwm_pin"], right_expected
+    )
 
 
 def test_emergency_stop_cuts_power_and_blocks_new_commands(camjam_config, pigpio_stub):

--- a/tests/hardware/sensors/test_camjam.py
+++ b/tests/hardware/sensors/test_camjam.py
@@ -2,13 +2,11 @@ import asyncio
 from dataclasses import asdict
 
 import pytest
-
+from src.hardware.camjam.sensors.encoders import WheelEncoders
+from src.hardware.camjam.sensors.line_follow import LineFollower
+from src.hardware.camjam.sensors.ultrasonic import UltrasonicRanger
 
 pytestmark = pytest.mark.camjam_unit
-
-from src.hardware.camjam.sensors.ultrasonic import UltrasonicRanger, UltrasonicReading
-from src.hardware.camjam.sensors.line_follow import LineFollower, LineTelemetry
-from src.hardware.camjam.sensors.encoders import WheelEncoders, EncoderTelemetry
 
 
 class AsyncIteratorStub:
@@ -72,7 +70,9 @@ def test_line_follow_normalization_and_hysteresis():
 
         assert reading_2.on_line
         assert reading_3.on_line
-        assert not reading_4.on_line, "Hysteresis should release once both fall below inactive threshold"
+        assert not reading_4.on_line, (
+            "Hysteresis should release once both fall below inactive threshold"
+        )
 
         left_values = [reading_1.left, reading_2.left, reading_3.left, reading_4.left]
         assert left_values[1] > left_values[0], "EMA should respond to increasing reflectance"

--- a/tests/services/test_camjam_diagnostics.py
+++ b/tests/services/test_camjam_diagnostics.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import math
-from typing import Dict
 
 import pytest
-
+from src.services.diagnostics.camjam import CamJamDiagnostics
 
 pytestmark = pytest.mark.camjam_unit
-
-from src.services.diagnostics.camjam import CamJamDiagnostics
 
 
 class TimeStub:
@@ -34,7 +31,6 @@ def diagnostics(time_stub: TimeStub) -> CamJamDiagnostics:
 
 def _strip_timestamps(events):
     """Replace volatile timestamps with sentinel for snapshot comparisons."""
-
     sanitized = []
     for event in events:
         event = dict(event)
@@ -93,7 +89,7 @@ def test_line_sensor_and_camera_status(diagnostics: CamJamDiagnostics, time_stub
     diagnostics.record_stream_status(status="live", detail="Operational")
 
     payload = diagnostics.ui_payload()
-    line_history: Dict[str, list] = payload["line_sensors"]
+    line_history: dict[str, list] = payload["line_sensors"]
     assert line_history["left"][0]["active"] is False
     assert line_history["left"][1]["active"] is True
     assert line_history["center"][0]["active"] is True
@@ -116,7 +112,9 @@ def test_line_sensor_and_camera_status(diagnostics: CamJamDiagnostics, time_stub
     assert sanitized[2]["component"] == "video_stream"
 
 
-def test_health_reports_stale_when_no_updates(diagnostics: CamJamDiagnostics, time_stub: TimeStub) -> None:
+def test_health_reports_stale_when_no_updates(
+    diagnostics: CamJamDiagnostics, time_stub: TimeStub
+) -> None:
     diagnostics.record_motor_command(left_speed=0.1, right_speed=0.1)
     diagnostics.record_stream_status(status="live")
 

--- a/tests/simulation/test_camjam_sim.py
+++ b/tests/simulation/test_camjam_sim.py
@@ -1,22 +1,22 @@
+from __future__ import annotations
+
 import asyncio
 
 import pytest
-
-
-pytestmark = pytest.mark.camjam_simulation
-
-from src.simulation.camjam import (
-    list_scenarios,
-    load_scenario,
-    reset_simulation_context,
-    simulation_enabled,
-)
 from src.hardware.camjam import (
     get_motor_controller,
     get_pan_tilt_servos,
     get_ultrasonic_ranger,
     get_wheel_encoders,
 )
+from src.simulation.camjam import (
+    list_scenarios,
+    load_scenario,
+    reset_simulation_context,
+    simulation_enabled,
+)
+
+pytestmark = pytest.mark.camjam_simulation
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- migrate Ruff configuration to the new `[tool.ruff.lint]` table and limit checks to the error-focused E/F rules
- refresh simulation, diagnostics, and hardware helpers with modern typing/docstrings so that Ruff now passes under the tighter line-length rules
- tidy the API, test, and HIL utility modules to resolve unused imports and long lines reported by the updated lint pass

## Testing
- `ruff check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d997d1fd3c832fb25d0666047817c1