### PR TITLE
Fix Prettier formatting for PanTiltControl slider thumb

### DIFF
--- a/frontend/src/components/PanTiltControl.tsx
+++ b/frontend/src/components/PanTiltControl.tsx
@@ -143,12 +143,12 @@ export function PanTiltControl() {
             <Slider.Track className="relative h-2 w-full grow rounded-full bg-slate-700">
               <Slider.Range className="absolute h-full rounded-full bg-brand-400" />
             </Slider.Track>
-          <Slider.Thumb
-            className="block h-5 w-5 rounded-full border border-slate-200 bg-white shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
-            aria-valuemin={PAN_RANGE[0]}
-            aria-valuemax={PAN_RANGE[1]}
-            aria-label="Pan angle"
-          />
+            <Slider.Thumb
+              className="block h-5 w-5 rounded-full border border-slate-200 bg-white shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
+              aria-valuemin={PAN_RANGE[0]}
+              aria-valuemax={PAN_RANGE[1]}
+              aria-label="Pan angle"
+            />
           </Slider.Root>
         </div>
 
@@ -169,12 +169,12 @@ export function PanTiltControl() {
             <Slider.Track className="relative h-2 w-full grow rounded-full bg-slate-700">
               <Slider.Range className="absolute h-full rounded-full bg-brand-400" />
             </Slider.Track>
-          <Slider.Thumb
-            className="block h-5 w-5 rounded-full border border-slate-200 bg-white shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
-            aria-valuemin={TILT_RANGE[0]}
-            aria-valuemax={TILT_RANGE[1]}
-            aria-label="Tilt angle"
-          />
+            <Slider.Thumb
+              className="block h-5 w-5 rounded-full border border-slate-200 bg-white shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
+              aria-valuemin={TILT_RANGE[0]}
+              aria-valuemax={TILT_RANGE[1]}
+              aria-label="Tilt angle"
+            />
           </Slider.Root>
         </div>
 


### PR DESCRIPTION
## Summary
- reformat the Slider.Thumb elements in PanTiltControl to satisfy Prettier formatting

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d9ad43354c832fab1a0983a5bace4e